### PR TITLE
Fix closing of connections

### DIFF
--- a/odbc_fdw.c
+++ b/odbc_fdw.c
@@ -66,6 +66,7 @@ typedef struct odbcFdwExecutionState
     char			*svr_username;
     char			*svr_password;
     SQLHSTMT		stmt;
+    SQLHDBC                     dbc;
     int				num_of_result_cols;
     int				num_of_table_cols;
     StringInfoData	*table_columns;
@@ -605,6 +606,7 @@ odbcGetTableSize(char *svr_dsn, char *svr_database, char *svr_schema, char *svr_
     }
     if (dbc)
     {
+        SQLDisconnect(dbc);
         SQLFreeHandle(SQL_HANDLE_DBC, dbc);
         dbc = NULL;
     }
@@ -613,8 +615,6 @@ odbcGetTableSize(char *svr_dsn, char *svr_database, char *svr_schema, char *svr_
         SQLFreeHandle(SQL_HANDLE_ENV, env);
         env = NULL;
     }
-    if (dbc)
-        SQLDisconnect(dbc);
 #ifdef DEBUG
     elog(NOTICE, "Count:   %u", *size);
 #endif
@@ -976,6 +976,7 @@ odbcBeginForeignScan(ForeignScanState *node, int eflags)
     festate->svr_table = svr_table;
     festate->svr_username = username;
     festate->svr_password = password;
+    festate->dbc = dbc;
     festate->stmt = stmt;
     festate->table_columns = columns;
     festate->num_of_table_cols = num_of_columns;
@@ -1253,6 +1254,11 @@ odbcEndForeignScan(ForeignScanState *node)
 
     if (festate)
     {
+        if (festate->dbc)
+        {
+            SQLDisconnect(festate->dbc);
+            SQLFreeHandle(SQL_HANDLE_DBC, festate->dbc);
+        }
         if (festate->stmt)
         {
             SQLFreeHandle(SQL_HANDLE_STMT, festate->stmt);


### PR DESCRIPTION
Hello Andrew,
after using your 9.3 version for a while we experienced a huge amount of established but otherwise unused connections to our ODBC server. Some research showed a patch to close connections in another fork (https://github.com/klando/odbc_fdw/commit/61fe4f55d715c9f97c77b0555b61e1a0f97b341a), and I applied that to your code.

Are changes needed to use this code with Pg 9.4, and if so, are you planning to create a REL9_4 branch :) ?

Thanks for REL9_3, 
Dirk